### PR TITLE
Allowing epsilon rules.

### DIFF
--- a/cfpq-cpp/Grammar.cpp
+++ b/cfpq-cpp/Grammar.cpp
@@ -29,7 +29,9 @@ Grammar::Grammar(const string &grammar_filename) {
         if (!nonterminal_to_index.count(terms[0])) {
             nonterminal_to_index[terms[0]] = nonterminals_count++;
         }
-        if (terms.size() == 2) {
+        if (terms.size() == 1) {
+            epsilon_nonterminals.push_back(nonterminal_to_index[terms[0]]);
+        } else if (terms.size() == 2) {
             if (!terminal_to_nonterminals.count(terms[1])) {
                 terminal_to_nonterminals[terms[1]] = {};
             }

--- a/cfpq-cpp/Grammar.h
+++ b/cfpq-cpp/Grammar.h
@@ -44,6 +44,12 @@ public:
             }
         }
 
+        for (unsigned int nonterm : epsilon_nonterminals) {
+            for (unsigned int i = 0; i < vertices_count; ++i) {
+                matrices[nonterm]->set_bit(i, i);
+            }
+        }
+
         using namespace std::chrono;
         high_resolution_clock::time_point begin_time = high_resolution_clock::now();
         environment->environment_preprocessing(matrices);
@@ -83,6 +89,7 @@ private:
     std::unordered_set<unsigned int> to_recalculate;
     std::vector<std::vector<unsigned int>> rules_with_nonterminal;
     std::map<std::string, unsigned int> nonterminal_to_index;
+    std::vector<unsigned int> epsilon_nonterminals;
     std::unordered_map<std::string, std::vector<int>> terminal_to_nonterminals;
     std::vector<std::pair<unsigned int, nonterminals_pair>> rules;
     std::vector<Matrix *> matrices;

--- a/python/main.py
+++ b/python/main.py
@@ -12,13 +12,13 @@ from utils import time_measure, mat_hash
 
 
 VERBOSE = False
-
+EPS = "epsilon"
 
 def main(grammar_file, graph_file, args):
-    grammar, inverse_grammar = parse_grammar(grammar_file)
+    grammar, inverse_grammar = parse_grammar(grammar_file, EPS)
     graph, graph_size = parse_graph(graph_file)
 
-    matrices = get_boolean_adjacency_matrices(grammar, inverse_grammar, graph, graph_size, mat_type=args.type)
+    matrices = get_boolean_adjacency_matrices(grammar, inverse_grammar, graph, graph_size, mat_type=args.type, EPS)
     remove_terminals(grammar, inverse_grammar)
 
     if not args.on_cpu:

--- a/python/math_utils.py
+++ b/python/math_utils.py
@@ -29,7 +29,7 @@ def set_bit_sparse(pairs, row, col):
     pairs[1].append(col)
 
 
-def get_boolean_adjacency_matrices(grammar, inv_grammar, graph, graph_size, mat_type='bool'):
+def get_boolean_adjacency_matrices(grammar, inv_grammar, graph, graph_size, mat_type='bool', EPS):
     global size
     if mat_type  == 'bool':
         set_bit = set_bit_bool
@@ -48,7 +48,7 @@ def get_boolean_adjacency_matrices(grammar, inv_grammar, graph, graph_size, mat_
             if value in inv_grammar:
                 for nonterminal in inv_grammar[value]:
                     set_bit(matrices[nonterminal], row, col)
-    for nonterminal in inv_grammar["epsilon"]:
+    for nonterminal in inv_grammar[EPS]:
         for i in range(graph_size):
             set_bit(matrices[nonterminal], i, i)
     if mat_type == 'sparse':

--- a/python/math_utils.py
+++ b/python/math_utils.py
@@ -48,6 +48,9 @@ def get_boolean_adjacency_matrices(grammar, inv_grammar, graph, graph_size, mat_
             if value in inv_grammar:
                 for nonterminal in inv_grammar[value]:
                     set_bit(matrices[nonterminal], row, col)
+    for nonterminal in inv_grammar["epsilon"]:
+        for i in range(graph_size):
+            set_bit(matrices[nonterminal], i, i)
     if mat_type == 'sparse':
         for key in matrices:
             matrices[key] = csr_matrix(([True] * len(matrices[key][0]), matrices[key]),

--- a/python/parsing.py
+++ b/python/parsing.py
@@ -6,8 +6,11 @@ def parse_grammar(_file):
     with open(_file, 'rt') as gramm:
         lines = gramm.readlines()
     for line in lines:
-        terms = line.split()
-        if len(terms) == 2:
+        terms = line.strip().split()
+        if len(terms) == 1:
+            grammar[terms[0]].add("epsilon")
+            inverse_grammar["epsilon"].add(terms[0])
+        elif len(terms) == 2:
             grammar[terms[0]].add(terms[1])
             inverse_grammar[terms[1]].add(terms[0])
         elif len(terms) == 3:

--- a/python/parsing.py
+++ b/python/parsing.py
@@ -1,15 +1,15 @@
 from collections import defaultdict
 
 
-def parse_grammar(_file):
+def parse_grammar(_file, EPS):
     grammar, inverse_grammar = defaultdict(set), defaultdict(set)
     with open(_file, 'rt') as gramm:
         lines = gramm.readlines()
     for line in lines:
         terms = line.strip().split()
         if len(terms) == 1:
-            grammar[terms[0]].add("epsilon")
-            inverse_grammar["epsilon"].add(terms[0])
+            grammar[terms[0]].add(EPS)
+            inverse_grammar[EPS].add(terms[0])
         elif len(terms) == 2:
             grammar[terms[0]].add(terms[1])
             inverse_grammar[terms[1]].add(terms[0])

--- a/test_utils/build_testset.py
+++ b/test_utils/build_testset.py
@@ -25,7 +25,7 @@ def main(data_folder):
                         n_edge = 0
                         for line in f:
                             n_edge += 1
-                            u, _, v = line.split(' ')
+                            u, _, v = line.strip().split(' ')
                             n_vert = max(n_vert, max(int(u), int(v)))
                         n_vert += 1
                     cache[path_to_matrix] = (n_vert, n_edge)


### PR DESCRIPTION
Now epsilon rules is allowed in grammars (line which consists of just one nonterminal symbol). Also fixed some problems with using .split() without .strip().